### PR TITLE
docker image frolvlad/alpine-oraclejdk8:slim changed to frolvlad/alpi…

### DIFF
--- a/1_ECS_Java_Spring_PetClinic/src/main/docker/Dockerfile
+++ b/1_ECS_Java_Spring_PetClinic/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:slim
+FROM frolvlad/alpine-oraclejre8:slim
 VOLUME /tmp
 ADD spring-petclinic-rest-1.7.jar app.jar
 RUN sh -c 'touch /app.jar'


### PR DESCRIPTION
…ne-oraclejre8:slim

*Issue #15 

*Description of changes:*
Docker image frolvlad/alpine-oraclejdk8:slim is not available. it needs to be replaced with alpine-oraclejre8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
